### PR TITLE
feat: add FastAPI entrypoint parameters to span

### DIFF
--- a/falken_trace/config.py
+++ b/falken_trace/config.py
@@ -7,6 +7,7 @@ class EnvVarsConfig:
     def __init__(self) -> None:
         self.dd_trace_enabled = is_dd_trace_enabled()
         self.falken_trace_enabled = os.environ.get("FALKEN_TRACE_ENABLED", "true").lower() in ("true", "1")
+        self.falken_include_params = os.environ.get("FALKEN_INCLUDE_PARAMS", "true").lower() in ("true", "1")
 
 
 env_vars_config = EnvVarsConfig()

--- a/falken_trace/utils.py
+++ b/falken_trace/utils.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import os
 from importlib.util import find_spec
+from typing import Any
 
 
 # method 'str.removeprefix()' was added in Python 3.9
@@ -11,6 +14,18 @@ def removeprefix(input_str: str, prefix: str) -> str:
 
 def normalize_path(path: str, path_prefix: str) -> str:
     return removeprefix(path, path_prefix).lstrip("/")
+
+
+def flatten_dict(data: dict[str, Any], parent_key: str = "") -> dict[str, str]:
+    """Creates a single level dict by concatenating keys with dots and values as strings."""
+    items = {}
+    for key, value in data.items():
+        new_key = f"{parent_key}.{key}" if parent_key else key
+        if isinstance(value, dict):
+            items.update(flatten_dict(value, new_key))
+        else:
+            items[new_key] = str(value)
+    return items
 
 
 def is_dd_trace_enabled() -> bool:

--- a/falken_trace/web/fastapi.py
+++ b/falken_trace/web/fastapi.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import inspect
 import os
 from collections.abc import Awaitable
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from typing_extensions import ParamSpec
 
 from falken_trace.config import env_vars_config
-from falken_trace.utils import normalize_path, removeprefix
+from falken_trace.utils import flatten_dict, normalize_path, removeprefix
+
+if TYPE_CHECKING:
+    from ddtrace import Span
 
 if env_vars_config.dd_trace_enabled:
     from ddtrace import tracer
@@ -44,7 +47,20 @@ async def wrap_fastapi_entrypoint_span(
             span.set_tag("code.lineno", str(lineno))
             span.set_tag("code.func", line)
 
+            if env_vars_config.falken_include_params and (values := kwargs.get("values")):
+                attach_func_params(span=span, param_args=values)
+
     if inspect.iscoroutinefunction(wrapped):
         return await wrapped(*args, **kwargs)
     else:
         return wrapped(*args, **kwargs)  # type:ignore[return-value]
+
+
+def attach_func_params(span: Span, param_args: dict[str, Any]) -> None:
+    for param, arg in param_args.items():
+        if hasattr(arg, "model_dump"):  # true, if `pydantic.BaseModel`
+            flat = flatten_dict(arg.model_dump())
+            for flat_key, value in flat.items():
+                span.set_tag(f"params.{param}.{flat_key}", value)
+        else:
+            span.set_tag(f"params.{param}", arg)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+from falken_trace.utils import flatten_dict
+
+
+def test_flatten_dict() -> None:
+    # given
+    data = {
+        "1": {"2": 3},
+        "4": True,
+        "5": {
+            "6": {
+                "7": ["8"],
+            }
+        },
+    }
+
+    # when
+    flat = flatten_dict(data)
+
+    # then
+    assert flat == {
+        "1.2": "3",
+        "4": "True",
+        "5.6.7": "['8']",
+    }

--- a/tests/web/test_fastapi.py
+++ b/tests/web/test_fastapi.py
@@ -1,5 +1,7 @@
 from typing import Dict, Optional
 
+from typing_extensions import Annotated
+
 
 def test_wrap_fastapi_entrypoint_span_with_sync_func() -> None:
     # given
@@ -31,7 +33,7 @@ def test_wrap_fastapi_entrypoint_span_with_sync_func() -> None:
     tags = span.get_tags()
 
     assert tags.get("code.filepath").endswith("test_fastapi.py")
-    assert tags.get("code.lineno") == "20"
+    assert tags.get("code.lineno") == "22"
     assert tags.get("code.func") == "hello"
 
 
@@ -65,5 +67,79 @@ def test_wrap_fastapi_entrypoint_span_with_async_func() -> None:
     tags = span.get_tags()
 
     assert tags.get("code.filepath").endswith("test_fastapi.py")
-    assert tags.get("code.lineno") == "54"
+    assert tags.get("code.lineno") == "56"
     assert tags.get("code.func") == "ahello"
+
+
+def test_wrap_fastapi_entrypoint_span_with_str_payload() -> None:
+    # given
+    import falken_trace  # noqa
+
+    import ddtrace
+
+    ddtrace.patch(fastapi=True)
+
+    from fastapi import Body, FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    span: Optional[ddtrace.Span] = None  # can't use the newer syntax here, otherwise the FastAPI setup breaks
+
+    @app.post("/")
+    async def ahello(body: Annotated[str, Body(media_type="text/plain")]) -> Dict[str, str]:  # noqa: RUF029
+        nonlocal span  # bind current span to check, if everything was set at the end
+        span = ddtrace.tracer.current_span()
+        return {"msg": f"Hello {body}"}
+
+    client = TestClient(app)
+
+    # when
+    client.post("/", content="World", headers={"Content-Type": "text/plain"})
+
+    # then
+    tags = span.get_tags()
+
+    assert tags.get("code.func") == "ahello"
+    assert tags.get("params.body") == "World"
+
+
+def test_wrap_fastapi_entrypoint_span_with_base_model_payload() -> None:
+    # given
+    import falken_trace  # noqa
+
+    import ddtrace
+
+    ddtrace.patch(fastapi=True)
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from pydantic import BaseModel
+
+    class Item(BaseModel):
+        name: str
+        description: Optional[str] = None
+
+    app = FastAPI()
+
+    span: Optional[ddtrace.Span] = None  # can't use the newer syntax here, otherwise the FastAPI setup breaks
+
+    @app.post("/items/")
+    async def create_item(item: Item) -> Item:  # noqa: RUF029
+        nonlocal span  # bind current span to check, if everything was set at the end
+        span = ddtrace.tracer.current_span()
+        return item
+
+    client = TestClient(app)
+
+    payload = {"name": "Foo", "description": "An optional description"}
+
+    # when
+    client.post("/items/", json=payload)
+
+    # then
+    tags = span.get_tags()
+
+    assert tags.get("code.func") == "create_item"
+    assert tags.get("params.item.name") == "Foo"
+    assert tags.get("params.item.description") == "An optional description"


### PR DESCRIPTION
<!-- user_description heading -->
# User description
<!-- user_description start -->
- function parameters for API entrypoints are added to the span under the `params` field and flatten out, so Datadog can properly visualize them as a dict
- if needed, it can be turned off via `FALKEN_INCLUDE_PARAMS` env var

ex.
<img width="553" alt="image" src="https://github.com/user-attachments/assets/aa32b0ed-c1ea-4894-be32-21bc46b8f3ae">

<!-- user_description end -->

---

<!-- generated_description heading -->
# Generated description
<!-- generated_description start -->
This pull request introduces the ability to include FastAPI entrypoint parameters in spans by adding a new configuration option `falken_include_params` in `EnvVarsConfig`. It also implements a utility function `flatten_dict` to handle nested dictionary structures, and updates the `wrap_fastapi_entrypoint_span` function to attach function parameters to spans. Tests are added to verify the new functionality.

## Topics
### Add FastAPI entrypoint parameters to spans
* [`falken_trace/web/fastapi.py`](https://github.com/baz-scm/falken-trace-py/pull/17/files#diff-dfe99093ab0dc5f43555dc643a59244b5f444a736b08477424547a14bfef2d37)
* [`tests/web/test_fastapi.py`](https://github.com/baz-scm/falken-trace-py/pull/17/files#diff-c2f436a77d5980df14f437bf028afa8961a49df1dd8de7e561656034d1bb47d0)
### Add configuration for including parameters in spans
* [`falken_trace/config.py`](https://github.com/baz-scm/falken-trace-py/pull/17/files#diff-a9f30cccce5d4bb5cee7b84fcab7f160b82f190a2d7edf22e35338f30b2d2e47)
### Implement utility function for flattening dictionaries
* [`falken_trace/utils.py`](https://github.com/baz-scm/falken-trace-py/pull/17/files#diff-429a3432dbe52ec31420f80ead0d903b70736cbb4d91301b65db296bbb2b4d9a)
* [`tests/test_utils.py`](https://github.com/baz-scm/falken-trace-py/pull/17/files#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33)

<!-- generated_description end -->