### PR TITLE
perf: improve frame info extraction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-toml
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/falken_trace/tracing/datadog.py
+++ b/falken_trace/tracing/datadog.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Callable
 from typing_extensions import ParamSpec
 
 from falken_trace.config import env_vars_config
-from falken_trace.utils import normalize_path
+from falken_trace.utils import getouterframes, normalize_path
 
 if TYPE_CHECKING:
     from ddtrace import Span, Tracer
@@ -21,7 +21,7 @@ def wrap_dd_span(wrapped: Callable[P, Span], _instance: Tracer, args: P.args, kw
         return span
 
     work_dir = os.getcwd()
-    for frame_info in inspect.stack()[1:]:  # first frame is itself
+    for frame_info in getouterframes(inspect.currentframe()):
         if frame_info.function == "func_wrapper" and "ddtrace" in frame_info.filename:  # noqa: SIM102
             # trying to get the actual definition of the callable
             if (func := frame_info.frame.f_locals.get("f")) or (func := frame_info.frame.f_locals.get("coro")):

--- a/falken_trace/tracing/datadog.py
+++ b/falken_trace/tracing/datadog.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Callable
 from typing_extensions import ParamSpec
 
 from falken_trace.config import env_vars_config
-from falken_trace.utils import getouterframes, normalize_path
+from falken_trace.utils import get_outer_frames, normalize_path
 
 if TYPE_CHECKING:
     from ddtrace import Span, Tracer
@@ -21,7 +21,7 @@ def wrap_dd_span(wrapped: Callable[P, Span], _instance: Tracer, args: P.args, kw
         return span
 
     work_dir = os.getcwd()
-    for frame_info in getouterframes(inspect.currentframe()):
+    for frame_info in get_outer_frames(inspect.currentframe()):
         if frame_info.function == "func_wrapper" and "ddtrace" in frame_info.filename:  # noqa: SIM102
             # trying to get the actual definition of the callable
             if (func := frame_info.frame.f_locals.get("f")) or (func := frame_info.frame.f_locals.get("coro")):

--- a/falken_trace/utils.py
+++ b/falken_trace/utils.py
@@ -10,16 +10,16 @@ if TYPE_CHECKING:
     from types import FrameType
 
 
-def getouterframes(frame: FrameType | None, max_frames: int = 5) -> Iterator[inspect.FrameInfo]:
+def get_outer_frames(frame: FrameType | None, max_frames: int = 5) -> Iterator[inspect.FrameInfo]:
     """Get a records for a frame and all higher (calling) frames.
 
     Copied and adjusted version of inspect.getouterframes()
     """
     frame_count = 0
     while frame and frame_count < max_frames:
-        frameinfo = (frame,) + inspect.getframeinfo(frame, 0)  # noqa: RUF005
+        frame_info = (frame,) + inspect.getframeinfo(frame, 0)  # noqa: RUF005
         if frame_count:  # the first frame is itself
-            yield inspect.FrameInfo(*frameinfo)
+            yield inspect.FrameInfo(*frame_info)
         frame = frame.f_back
         frame_count += 1
 

--- a/falken_trace/utils.py
+++ b/falken_trace/utils.py
@@ -1,8 +1,27 @@
 from __future__ import annotations
 
+import inspect
 import os
 from importlib.util import find_spec
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import FrameType
+
+
+def getouterframes(frame: FrameType | None, max_frames: int = 5) -> Iterator[inspect.FrameInfo]:
+    """Get a records for a frame and all higher (calling) frames.
+
+    Copied and adjusted version of inspect.getouterframes()
+    """
+    frame_count = 0
+    while frame and frame_count < max_frames:
+        frameinfo = (frame,) + inspect.getframeinfo(frame, 0)  # noqa: RUF005
+        if frame_count:  # the first frame is itself
+            yield inspect.FrameInfo(*frameinfo)
+        frame = frame.f_back
+        frame_count += 1
 
 
 # method 'str.removeprefix()' was added in Python 3.9


### PR DESCRIPTION
# User description
- copied and adjusted the `inspect. getouterframes()` function to yield a maximum of 5 frames, instead of collecting all, which was not needed
- this cuts time by at least 50% and also memory usage by quite lot depending on the depth of the stack

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Optimizes frame info extraction by implementing a custom <code>get_outer_frames()</code> function in <code>falken_trace/utils.py</code>. This function limits the number of frames to 5, replacing the use of <code>inspect.stack()</code> in <code>falken_trace/tracing/datadog.py</code>. Additionally, updates the Ruff pre-commit hook to version 0.9.6.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/falken-trace-py/42?tool=ast&topic=Dependency+Update>Dependency Update</a>
        </td><td>Updates the Ruff pre-commit hook to version 0.9.6<details><summary>Modified files (1)</summary><ul><li>.pre-commit-config.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>build-upgrade-poetry-t...</td><td>January 12, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/falken-trace-py/42?tool=ast&topic=Frame+Extraction+Opt>Frame Extraction Opt</a>
        </td><td>Implements a custom <code>get_outer_frames()</code> function to optimize frame info extraction<details><summary>Modified files (2)</summary><ul><li>falken_trace/tracing/datadog.py</li>
<li>falken_trace/utils.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>feat-add-FastAPI-entry...</td><td>August 25, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @gruebel and the rest of your team on <a href=https://baz.co/changes/baz-scm/falken-trace-py/42?tool=ast>(Baz)</a>.
    