### PR TITLE
feat: support ddtrace v3

### DIFF
--- a/falken_trace/__init__.py
+++ b/falken_trace/__init__.py
@@ -6,6 +6,10 @@ from falken_trace.web.fastapi import wrap_fastapi_entrypoint_span
 
 if config.env_vars_config.falken_trace_enabled:
     if config.env_vars_config.dd_trace_enabled:
-        wrapt.wrap_function_wrapper("ddtrace", "Tracer.start_span", wrap_dd_span)
+        try:
+            wrapt.wrap_function_wrapper("ddtrace.trace", "Tracer.start_span", wrap_dd_span)
+        except AttributeError:
+            # fallback to v2 import
+            wrapt.wrap_function_wrapper("ddtrace", "Tracer.start_span", wrap_dd_span)
     if config.env_vars_config.fastapi_installed:
         wrapt.wrap_function_wrapper("fastapi.routing", "run_endpoint_function", wrap_fastapi_entrypoint_span)

--- a/falken_trace/tracing/datadog.py
+++ b/falken_trace/tracing/datadog.py
@@ -10,7 +10,7 @@ from falken_trace.config import env_vars_config
 from falken_trace.utils import get_outer_frames, normalize_path
 
 if TYPE_CHECKING:
-    from ddtrace import Span, Tracer
+    from ddtrace.trace import Span, Tracer
 
 P = ParamSpec("P")
 

--- a/falken_trace/web/fastapi.py
+++ b/falken_trace/web/fastapi.py
@@ -12,7 +12,7 @@ from falken_trace.utils import flatten_dict, normalize_path
 if TYPE_CHECKING:
     from collections.abc import Awaitable
 
-    from ddtrace import Span
+    from ddtrace.trace import Span
 
 if env_vars_config.dd_trace_enabled:
     try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -89,90 +89,81 @@ files = [
 
 [[package]]
 name = "ddtrace"
-version = "2.21.2"
+version = "3.2.1"
 description = "Datadog APM client library"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "ddtrace-2.21.2-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:807973daebd93cbcd79312da67e999ac3ff0ce19874b995b9d301a604a932dd4"},
-    {file = "ddtrace-2.21.2-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:25d188e8259d6e02b8c627980c37342f224229faf940c7e4f7f2b4f98a1ba2bb"},
-    {file = "ddtrace-2.21.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ba2b416f810fd00ab462abf6e9097ae7b2ea220864cd667a96dbd39cf6f307c"},
-    {file = "ddtrace-2.21.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a15ab5a95d5ab58279fa9a35d5aa98ffb475060575da82266af58dfc3a96f55e"},
-    {file = "ddtrace-2.21.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a2531d3de9236e8edd8c7edadd34e0fe932a738c8a49ade831cc8a55713610b"},
-    {file = "ddtrace-2.21.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3e8cf410161a2ff9d56ae54221ea8467ef92eef75f080c0e8753f9e5b19e7d9b"},
-    {file = "ddtrace-2.21.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5e9b69bf5d6f8aa54b84e947833ff201e8c96f45adf1ebe333ce29392fe8e585"},
-    {file = "ddtrace-2.21.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0b749f499accad1d87c5a09980ca80167084fd9262256fdf78d56e56fa12bea3"},
-    {file = "ddtrace-2.21.2-cp310-cp310-win32.whl", hash = "sha256:e047675651a5ebd878c1cd041761fc5d8c87aa59a29686d4bc596a2883374d4e"},
-    {file = "ddtrace-2.21.2-cp310-cp310-win_amd64.whl", hash = "sha256:18bf1003da755a90261209d9920ddc294164ae6597c221d22ef70a982938b692"},
-    {file = "ddtrace-2.21.2-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:94e5a4466ec16e7844cf68f6153c9024815c8e58a1c2ba990bc18b0d75563ed6"},
-    {file = "ddtrace-2.21.2-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:f02d5d59f92d1b40a398a98f2f283e24d27651b7993977a49ca7f5c5c210a530"},
-    {file = "ddtrace-2.21.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cee46ea13e65012e16c17ceb8e6b6d70fbc8614132ad6898372594bc2538d65e"},
-    {file = "ddtrace-2.21.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:82fee76e50e981c9f745ad21e7f6b0a94f2de66e31f0c1ffd436f0e632076b0e"},
-    {file = "ddtrace-2.21.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4932ae23edd1b28bd6c7263313524a6ef15505a5a552fe1be63fd62f4ef2318"},
-    {file = "ddtrace-2.21.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ef5b8a862c5003cf2f50d7a1c56d8e0c8763286d8fe0815b5b439608712361ab"},
-    {file = "ddtrace-2.21.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c55a0f417f29cb4d361e96686c9411ce9e262778663e8b0be88d53b6c39d3fbb"},
-    {file = "ddtrace-2.21.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e04974a7987cecc7ea4b3df3b3731b0fbebcc3bce2cdf1fe49725fd9c61122bd"},
-    {file = "ddtrace-2.21.2-cp311-cp311-win32.whl", hash = "sha256:818076e43bf25a0d5e332e03b8430a0c20368b1a2682e9fb5f4bfc1157f537d1"},
-    {file = "ddtrace-2.21.2-cp311-cp311-win_amd64.whl", hash = "sha256:cdfa5b33911c3a399cb0c6fbfc10506e0e07c5678e8cd32a4240569fceb86864"},
-    {file = "ddtrace-2.21.2-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:f7463573b9fcddd937a7dba8fdb4e5a341c7fcf9b5493d1019ec21f1bc4e1b89"},
-    {file = "ddtrace-2.21.2-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:286599706dd48276f81cac44b32cb400471bdf82389df68356542c69e989c612"},
-    {file = "ddtrace-2.21.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e073e4798fb3d428fa93377c73556d9eb35700dd0e0be3adc174b3ef22ce86d9"},
-    {file = "ddtrace-2.21.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:507fc533315805975c19e68c902840b9243f133661bbad260160dbbd277df220"},
-    {file = "ddtrace-2.21.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d0a91fbde26df7390ca6faa28419f5f9de0f7921e5f47795b08fce623a764f3"},
-    {file = "ddtrace-2.21.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c7b4f837f1b3d4329703d7fee50426663770db36e6d443cb5acc2cf48c77208c"},
-    {file = "ddtrace-2.21.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:baa8f60d76528e1a9b33254e989efc5c954d76760b6342d74ebb256ff33d248d"},
-    {file = "ddtrace-2.21.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dc144a10274b5d4444cdd1013d3af1e9ff4f2bef98870c3e5081772e38b392a4"},
-    {file = "ddtrace-2.21.2-cp312-cp312-win32.whl", hash = "sha256:d246d3f23a1b6bfbfb186be3cae561d13f65a523a4066e8167aaef69434d449e"},
-    {file = "ddtrace-2.21.2-cp312-cp312-win_amd64.whl", hash = "sha256:b39a4c13e0061c630c06f212e376676b71442a80f82ad3e1d81713d4b53e5d57"},
-    {file = "ddtrace-2.21.2-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:36f372ae34e9d6492c4880ceddbf639471be2dca347ff8b8f0b32586b3d80069"},
-    {file = "ddtrace-2.21.2-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:299852f9baf3f73ddf84bc8c4ca6c57029c0b173217ae6cb66a7f08fd35a912a"},
-    {file = "ddtrace-2.21.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99c7475470a145cda44943e54a30ec30c91c5f841efb963a810b351c18ff9514"},
-    {file = "ddtrace-2.21.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:af54b2d7cd45680a025ea03e6a49e80831411c68027ff575fdc9d13588cb8f58"},
-    {file = "ddtrace-2.21.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b74fd0f98b0cc3a4c338675c094415838e465bbec7f00ee80a7104366e6fdba"},
-    {file = "ddtrace-2.21.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:822b2025c17fb0d8acdab695bcee827e050d6e6d17b50bfb74b360897a9b02d0"},
-    {file = "ddtrace-2.21.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a0b37d6461e0cc074899eb720a40505c25dd12d8a48b58ec9e21df80526ce13f"},
-    {file = "ddtrace-2.21.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2029ea9c279203177d8a575344b422b36832b3583019cd67817c9bfab2416df8"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-macosx_12_0_x86_64.whl", hash = "sha256:4535be9550869941f14e585085da779d7c8e6d258410b0a2eda5e32ec87ebde2"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a77e6620839cb0747128c1a74d1b98e861ff0bfa32964f0cd9f94f360df3dfac"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb0af9fd9e98e10651afc4473b5edf8ab1ff812c4ce806e68bf25a4cc4f43412"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50b28683b9bc1d370edda11ab30a8eb93589dce9ba39a15521ea5b86d3c80923"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:b3929add80f66b7613fef9060821001485e3d91ef6a9c857ce1789be60a612e8"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:29747a2448d893bb69407d36cb6b0e7ab5b9498dac47b3227ee3c78174f3c5da"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:611615018c0582b2d77567fd7b44398da7a49b5452c7c9e000e424d72918dcef"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-win32.whl", hash = "sha256:0a65e383fe03bce2a555a96f0ba28b7f875d11e31b8c89acfee514e4ba1e11c6"},
-    {file = "ddtrace-2.21.2-cp37-cp37m-win_amd64.whl", hash = "sha256:9b13390a73ae2b6c15653d2a2869d521381515c592056f9206e6835368ee881b"},
-    {file = "ddtrace-2.21.2-cp38-cp38-macosx_12_0_universal2.whl", hash = "sha256:034835b02c91bf0bbf368fbd60ff6eef929ff88cef66aaebbf58823614ab39d2"},
-    {file = "ddtrace-2.21.2-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:5dea2cd0618c1997a2d4ac6cdd0a1f357f71f210bf553afe4e056f475b1c5224"},
-    {file = "ddtrace-2.21.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df633777cfc98d878ad22b8a11c497c466c09fcd579bd20d47fa20bbd74b43de"},
-    {file = "ddtrace-2.21.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4abcd475df69853a2e3c9732c6c673726c451d0e524aa5264e46147c7b1b5afa"},
-    {file = "ddtrace-2.21.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c7760080f886909e42dc07e06304791a54c7480249862036bf61fa024e7e9da"},
-    {file = "ddtrace-2.21.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:111275c2ae793677390d467c1d601a6da598b53aafe2f6a1feaa29ae96a6a642"},
-    {file = "ddtrace-2.21.2-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:3352a885d56bbae4540f6bf1bda4aedee9ba9fb27d373742de2d42ea844ba2da"},
-    {file = "ddtrace-2.21.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:e3f1b45e6bfb911e873d4777dae050770c23e69284a1b0b623df206d68e3e5a7"},
-    {file = "ddtrace-2.21.2-cp38-cp38-win32.whl", hash = "sha256:bc2fa4f671ad2805f4e6ef4c1524c294460ae24467b31c2bc8724b51020096b9"},
-    {file = "ddtrace-2.21.2-cp38-cp38-win_amd64.whl", hash = "sha256:dbe1b46764278da2b415feaded0933e06d64197d66553cfa001eaad6f158b326"},
-    {file = "ddtrace-2.21.2-cp39-cp39-macosx_12_0_universal2.whl", hash = "sha256:b1f19fb974025cf5cfc7d5c749530e13a14913cc20965855d504bf92ff9130df"},
-    {file = "ddtrace-2.21.2-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:42c5b102077ef19491e19ccf308e92c32fcb9fda2b753ff1c8864194f07e2205"},
-    {file = "ddtrace-2.21.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fadbc291d5b7ee55b175f6dc355bb5f61a3cf3d30820d1daa4c7345cf4697afa"},
-    {file = "ddtrace-2.21.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65dec70679a835e8a37d93051ed00d33d481edbad4549577aebf8e4b3f636763"},
-    {file = "ddtrace-2.21.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:698bba82938bf5f6fc33e0f0c189391d0d32284c39887b401617735b1f870a79"},
-    {file = "ddtrace-2.21.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7073491f8632dcc7b4f4a3d02edf7533f77028f6490a126c20c52eabf633a507"},
-    {file = "ddtrace-2.21.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9c6279dd72d950533e30e4fd1b44e59ec7767e76aac72bdcf4102ebe346db463"},
-    {file = "ddtrace-2.21.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0a59ef4ce5f5456fbd0a8706fb34fd6c023e6af23309988c1b88b693f416be65"},
-    {file = "ddtrace-2.21.2-cp39-cp39-win32.whl", hash = "sha256:ea44a94ef002ba0f20af628f5a7e73e53b2ad86173e134290e2c55759121a910"},
-    {file = "ddtrace-2.21.2-cp39-cp39-win_amd64.whl", hash = "sha256:e67be7b5cc051c480019e0affc1b1a498a8e50df1b749b07875664e35e478e08"},
-    {file = "ddtrace-2.21.2.tar.gz", hash = "sha256:13e055298e2dd999d51e738b7d584fdf0391a86fedd3125c27a1a5bce1d89db7"},
+    {file = "ddtrace-3.2.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:912e5a824312861e877f6f976ab95c4eb01ab920cfaccc69c87dc5015309f6f4"},
+    {file = "ddtrace-3.2.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:d54a2383e7db6f28f395b771270ecacdeba32315ddb39f3c256b554271a0a513"},
+    {file = "ddtrace-3.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d5b3eea2eb6e5c5e2956ea8706906fad72cd3bd270297396a91db940511b075"},
+    {file = "ddtrace-3.2.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:429e95ec0cae4a10b506c9a2d010eaa7f40a73086c58eca40bb51c640d25c9bb"},
+    {file = "ddtrace-3.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56dec8fb650ad7b237706b1f16c76628eee7315b7820e5515c2844c3e2593005"},
+    {file = "ddtrace-3.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bdae569a745a38eb57003f8293056b2e9e736ca11753149b6b8b67c37ae74949"},
+    {file = "ddtrace-3.2.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d05d3745be16a92fba4fca9415376613c7e04f7dc47aaf6aaa4f9502e00e65cb"},
+    {file = "ddtrace-3.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b9b804dc73621e3cb867f6a6b03847d25c62798cdb1cca874fbfa4ce6e536105"},
+    {file = "ddtrace-3.2.1-cp310-cp310-win32.whl", hash = "sha256:994b02a566cbc33ed686ee03d23fea11741775096babe2b3a9b4fd8781cf65f6"},
+    {file = "ddtrace-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:d5c6c479841b0144017f3786197f0aa9bfb65bdc4d103a2e343aae8c0d065b5a"},
+    {file = "ddtrace-3.2.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4c463262a5c2381dae3776f51a335310e2474deaf863997f4f0393ec2fcb6442"},
+    {file = "ddtrace-3.2.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:9669924ef069a9f85c424837d73fb13377fef67d2926e7f68f06fef4467f7352"},
+    {file = "ddtrace-3.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8d0d3a4dd0dcff2af95666235838af29eae8fd489df8938527ad7d5f40db93c"},
+    {file = "ddtrace-3.2.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:793da357c0121ee8b9203d776e577d55ff9dd5c1ec827fd669bcc35058d7278b"},
+    {file = "ddtrace-3.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7cd268fc09e7183e3457963a1534331fd838b890da827db7e5ef992e6bd5e96"},
+    {file = "ddtrace-3.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:62c3aef2b677299947fefb899b914158a4f3af63cefb6f7c4d9d2cf06865ce44"},
+    {file = "ddtrace-3.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:90c641c97ad10475723fd12c5708247c2a796a4ccd5a27195502993b3baeb513"},
+    {file = "ddtrace-3.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b3852a62155fe0cc500c7a633cb76d3c14bf53e96d9c3936a0d24a22cee22d03"},
+    {file = "ddtrace-3.2.1-cp311-cp311-win32.whl", hash = "sha256:78b6683c3d8cbb3d1048f6d7742b12749790abfd6a24ed07d35c61c171167617"},
+    {file = "ddtrace-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:e28337b86e0dcb4c2573248bcbc6706406a2fa496f772495609594f5a50e7003"},
+    {file = "ddtrace-3.2.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:316f31a4354ab92208b46ed46df9009726831982b072ed79d7f1f411ac6a10af"},
+    {file = "ddtrace-3.2.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:4ae996fbe7c1e3a345b9dce96a030801597fec14b8284574252b2c4dc45a802d"},
+    {file = "ddtrace-3.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa39e9587b81c5d342166b9b1b9ea6751954f89324111d52984d9e1cffca4e57"},
+    {file = "ddtrace-3.2.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2beda81f25dad61cb657188f92199c603ee3aef5d9a53a2bf24e4cf2620e699"},
+    {file = "ddtrace-3.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fd86d1d47a5f82bb2bda73d339ec434427c5fcb2d259f825d18b097fc2fa3e1"},
+    {file = "ddtrace-3.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2cd1febea180a494e67ae0388055f3aaa8f63cb090dcf1ce4c3054c2162e05d1"},
+    {file = "ddtrace-3.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f8964c3cf0c3ef8dd066323b4ed0fbe561ca56f4a0bbe591b5e8e65411cc955f"},
+    {file = "ddtrace-3.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6a8ca3d670f4c3a873f24fcfb25f9324193b361edb57bbeadc3b90257a3494c2"},
+    {file = "ddtrace-3.2.1-cp312-cp312-win32.whl", hash = "sha256:c9ffa96777be82566c990a30216aac00ff84b256d7d0a428ed4a63e4666b6c3e"},
+    {file = "ddtrace-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:c2d6c34ed0f7986e9afbd8c991bb4e7049cc5631837708b400dd1c6b108058f9"},
+    {file = "ddtrace-3.2.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8db2b0aa025ac50b1a4516bdd722ede4a0d70d7c31df7b4ca0842aadfacc8276"},
+    {file = "ddtrace-3.2.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:65715768745d609e88d77e7a843477dd8e08da382f6058672210c412924d83af"},
+    {file = "ddtrace-3.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:003b5de6e28224129e8ba103bd8de26e7571b8c5a9141fdc70f91ad4b15fb4a0"},
+    {file = "ddtrace-3.2.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28a05aaa595e763ce7c46a4d186da2314c795ed7311efe506a58760f77ce3d13"},
+    {file = "ddtrace-3.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530cdd0570c5a5c9df420924f992800e90fcb5f556c1a2cd6d83ee4c3356072d"},
+    {file = "ddtrace-3.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c38fa59a6e999c7a95c508f3dd020a74173c77ca19517a2257394d7b4329331f"},
+    {file = "ddtrace-3.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:92de3eed2d2a3ed58a75ad8f44c2897614b9c905dba26b0d29989f849069896e"},
+    {file = "ddtrace-3.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:157617ee0a8a7a7dd55c9e0e293c8a9f01bc0cbeddc8f36e61d2ce0e95a04be3"},
+    {file = "ddtrace-3.2.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:0f52367b665ae75d47c444f709b650c2457cd92c76171c03de76247654ac0d76"},
+    {file = "ddtrace-3.2.1-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:d51d98b5714d9a02e6a919de211851170a829b88c407d1fb594dd0f72a241af3"},
+    {file = "ddtrace-3.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d47c042e5857c34d775858e0b1fde95bd4fe64b3dac27c7cb756fd593812077"},
+    {file = "ddtrace-3.2.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f73d78d58c2964c1073c4dc410edaa2de2d4a343878c19e06a4f14df3f1808d"},
+    {file = "ddtrace-3.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:752bd25994a191cc998029294f38b2355c76ad7c50a82705994695ac22a95675"},
+    {file = "ddtrace-3.2.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:dadcdc75300961d70367ac21e3b7f3b43e1df27894c7be84e14e23be00d7edc4"},
+    {file = "ddtrace-3.2.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:125f286749493a4cd6785425adc944b0df82c96b8c540c8dba2769b5ef42dc7c"},
+    {file = "ddtrace-3.2.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0c995c4e71db065a34d8a8657392180dded906ada73d33d0d5c8796070da1cbc"},
+    {file = "ddtrace-3.2.1-cp38-cp38-win32.whl", hash = "sha256:0d02456cf5839f33b78d66461cf0a6e8667669f9a440633687e4753f10505652"},
+    {file = "ddtrace-3.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:cd363d87fdbcd6ec4a4096e287d21a133758eea36abe7928558b4ab709cb33cc"},
+    {file = "ddtrace-3.2.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8c9e672d05b0a0f6519d42b50ff5a09f40d61dc9c93780896a3557dcca16e658"},
+    {file = "ddtrace-3.2.1-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:03b2fb551b55bb82f150b1ebe85956a54fe79e137ba34a5e9a6e15ae6ceb53a0"},
+    {file = "ddtrace-3.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2023770220a263f40684570293045f13ca6f664140ce88f53d4e3936e4fa661b"},
+    {file = "ddtrace-3.2.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4762448408b3365108c5636a947c018c494af7e69526a65046290df284b4ee96"},
+    {file = "ddtrace-3.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:347f21d1fef2884bbcfdf183406b25e5a8b26973ae15bf5b37d9461d6a229ea3"},
+    {file = "ddtrace-3.2.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:074abe5a3e887175e7fd3132531353279aeaa89cf113b7e9a75549bf7cc94e7a"},
+    {file = "ddtrace-3.2.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2b518df5d907a8427cd60007b5169cd649fc55c1f972dab3ebf6abfff757d3ed"},
+    {file = "ddtrace-3.2.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3a7a225953b991712aa57d8680063db5d078d9d11a1a3fc5c8bf2da0880f7717"},
+    {file = "ddtrace-3.2.1-cp39-cp39-win32.whl", hash = "sha256:76b44972e3d1201c88f56a56ec2ea46c4fb98735a92e2dab1957b694498a91a1"},
+    {file = "ddtrace-3.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:0877e52e46039f3a41a7e423f8b70d22635c66b397f33207a89897a598ed3228"},
+    {file = "ddtrace-3.2.1.tar.gz", hash = "sha256:d7fd33aa80131bc7cc619cd5bc63395c8ae2566aa49e5877d8d4295044b07ddd"},
 ]
 
 [package.dependencies]
 bytecode = [
     {version = ">=0.16.0", markers = "python_version >= \"3.13.0\""},
-    {version = ">=0.15.0", markers = "python_version ~= \"3.12.0\""},
+    {version = ">=0.15.1", markers = "python_version ~= \"3.12.0\""},
     {version = ">=0.14.0", markers = "python_version ~= \"3.11.0\""},
     {version = ">=0.13.0", markers = "python_version < \"3.11.0\""},
 ]
-envier = ">=0.5,<1.0"
+envier = ">=0.6.1,<0.7.0"
 legacy-cgi = {version = ">=2.0.0", markers = "python_version >= \"3.13.0\""}
 opentelemetry-api = ">=1"
 protobuf = ">=3"
@@ -247,19 +238,19 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.115.8"
+version = "0.115.11"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "fastapi-0.115.8-py3-none-any.whl", hash = "sha256:753a96dd7e036b34eeef8babdfcfe3f28ff79648f86551eb36bfc1b0bf4a8cbf"},
-    {file = "fastapi-0.115.8.tar.gz", hash = "sha256:0ce9111231720190473e222cdf0f07f7206ad7e53ea02beb1d2dc36e2f0741e9"},
+    {file = "fastapi-0.115.11-py3-none-any.whl", hash = "sha256:32e1541b7b74602e4ef4a0260ecaf3aadf9d4f19590bba3e1bf2ac4666aa2c64"},
+    {file = "fastapi-0.115.11.tar.gz", hash = "sha256:cc81f03f688678b92600a65a5e618b93592c65005db37157147204d8924bf94f"},
 ]
 
 [package.dependencies]
 pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.40.0,<0.46.0"
+starlette = ">=0.40.0,<0.47.0"
 typing-extensions = ">=4.8.0"
 
 [package.extras]
@@ -344,14 +335,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "identify"
-version = "2.6.7"
+version = "2.6.9"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "identify-2.6.7-py2.py3-none-any.whl", hash = "sha256:155931cb617a401807b09ecec6635d6c692d180090a1cedca8ef7d58ba5b6aa0"},
-    {file = "identify-2.6.7.tar.gz", hash = "sha256:3fa266b42eba321ee0b2bb0936a6a6b9e36a1351cbb69055b3082f4193035684"},
+    {file = "identify-2.6.9-py2.py3-none-any.whl", hash = "sha256:c98b4322da415a8e5a70ff6e51fbc2d2932c015532d77e9f8537b4ba7813b150"},
+    {file = "identify-2.6.9.tar.gz", hash = "sha256:d40dfe3142a1421d8518e3d3985ef5ac42890683e32306ad614a29490abeb6bf"},
 ]
 
 [package.extras]
@@ -671,23 +662,21 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "protobuf"
-version = "5.29.3"
+version = "6.30.0"
 description = ""
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888"},
-    {file = "protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a"},
-    {file = "protobuf-5.29.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8434404bbf139aa9e1300dbf989667a83d42ddda9153d8ab76e0d5dcaca484e"},
-    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84"},
-    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f"},
-    {file = "protobuf-5.29.3-cp38-cp38-win32.whl", hash = "sha256:84a57163a0ccef3f96e4b6a20516cedcf5bb3a95a657131c5c3ac62200d23252"},
-    {file = "protobuf-5.29.3-cp38-cp38-win_amd64.whl", hash = "sha256:b89c115d877892a512f79a8114564fb435943b59067615894c3b13cd3e1fa107"},
-    {file = "protobuf-5.29.3-cp39-cp39-win32.whl", hash = "sha256:0eb32bfa5219fc8d4111803e9a690658aa2e6366384fd0851064b963b6d1f2a7"},
-    {file = "protobuf-5.29.3-cp39-cp39-win_amd64.whl", hash = "sha256:6ce8cc3389a20693bfde6c6562e03474c40851b44975c9b2bf6df7d8c4f864da"},
-    {file = "protobuf-5.29.3-py3-none-any.whl", hash = "sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f"},
-    {file = "protobuf-5.29.3.tar.gz", hash = "sha256:5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620"},
+    {file = "protobuf-6.30.0-cp310-abi3-win32.whl", hash = "sha256:7337d76d8efe65ee09ee566b47b5914c517190196f414e5418fa236dfd1aed3e"},
+    {file = "protobuf-6.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:9b33d51cc95a7ec4f407004c8b744330b6911a37a782e2629c67e1e8ac41318f"},
+    {file = "protobuf-6.30.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:52d4bb6fe76005860e1d0b8bfa126f5c97c19cc82704961f60718f50be16942d"},
+    {file = "protobuf-6.30.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:7940ab4dfd60d514b2e1d3161549ea7aed5be37d53bafde16001ac470a3e202b"},
+    {file = "protobuf-6.30.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:d79bf6a202a536b192b7e8d295d7eece0c86fbd9b583d147faf8cfeff46bf598"},
+    {file = "protobuf-6.30.0-cp39-cp39-win32.whl", hash = "sha256:bb35ad251d222f03d6c4652c072dfee156be0ef9578373929c1a7ead2bd5492c"},
+    {file = "protobuf-6.30.0-cp39-cp39-win_amd64.whl", hash = "sha256:501810e0eba1d327e783fde47cc767a563b0f1c292f1a3546d4f2b8c3612d4d0"},
+    {file = "protobuf-6.30.0-py3-none-any.whl", hash = "sha256:e5ef216ea061b262b8994cb6b7d6637a4fb27b3fb4d8e216a6040c0b93bd10d7"},
+    {file = "protobuf-6.30.0.tar.gz", hash = "sha256:852b675d276a7d028f660da075af1841c768618f76b90af771a8e2c29e6f5965"},
 ]
 
 [[package]]
@@ -826,14 +815,14 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
-    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
+    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
 ]
 
 [package.dependencies]
@@ -924,14 +913,14 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.45.3"
+version = "0.46.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "starlette-0.45.3-py3-none-any.whl", hash = "sha256:dfb6d332576f136ec740296c7e8bb8c8a7125044e7c6da30744718880cdd059d"},
-    {file = "starlette-0.45.3.tar.gz", hash = "sha256:2cbcba2a75806f8a41c722141486f37c28e30a0921c5f6fe4346cb0dcee1302f"},
+    {file = "starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227"},
+    {file = "starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230"},
 ]
 
 [package.dependencies]
@@ -998,14 +987,14 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.29.2"
+version = "20.29.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-20.29.2-py3-none-any.whl", hash = "sha256:febddfc3d1ea571bdb1dc0f98d7b45d24def7428214d4fb73cc486c9568cce6a"},
-    {file = "virtualenv-20.29.2.tar.gz", hash = "sha256:fdaabebf6d03b5ba83ae0a02cfe96f48a716f4fae556461d180825866f75b728"},
+    {file = "virtualenv-20.29.3-py3-none-any.whl", hash = "sha256:3e3d00f5807e83b234dfb6122bf37cfadf4be216c53a49ac059d02414f819170"},
+    {file = "virtualenv-20.29.3.tar.gz", hash = "sha256:95e39403fcf3940ac45bc717597dba16110b74506131845d9b687d5e73d947ac"},
 ]
 
 [package.dependencies]
@@ -1141,4 +1130,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "b6bfb2774f0091018744ff20e10a164ad0f5860adb58454f9533e3bada77ae05"
+content-hash = "90ed2b776659dfee9bca367238791944edae3cf574059a9f4d6808d964cbc358"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ mypy = {extras = ["faster-cache"], version = "^1.15.0"}
 pre-commit = "^4.1.0"
 pytest = "^8.3.4"
 # integration tests
-ddtrace = "^2.18.1"
-fastapi = "^0.115.6"
+ddtrace = "^3.2.1"
+fastapi = "^0.115.11"
 # For the FastAPI test client
 httpx = ">=0.23.0"
 

--- a/tests/tracing/test_datadog.py
+++ b/tests/tracing/test_datadog.py
@@ -5,7 +5,7 @@ def test_wrap_dd_span_with_start_span() -> None:
     # given
     import falken_trace  # noqa
 
-    from ddtrace import Tracer
+    from ddtrace.trace import Tracer
 
     tracer = Tracer()
 
@@ -27,7 +27,7 @@ def test_wrap_dd_span_with_decorator() -> None:
     # given
     import falken_trace  # noqa
 
-    from ddtrace import tracer, Span
+    from ddtrace.trace import tracer, Span
 
     span: Span | None = None
 
@@ -59,7 +59,7 @@ def test_disbale_falken_trace(disbale_falken_trace) -> None:
     # given
     import falken_trace  # noqa
 
-    from ddtrace import Tracer
+    from ddtrace.trace import Tracer
 
     tracer = Tracer()
 


### PR DESCRIPTION
# User description
- left the previous import path from v2 as fallback, so both v2 and v3 are supported

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Updates the ddtrace library from version 2 to version 3, while maintaining backward compatibility. Modifies import statements and wrapping logic to support both versions. Updates related dependencies and test files to align with the new ddtrace version.</p>


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>build-upgrade-poetry-t...</td><td>January 12, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @gruebel and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/falken-trace-py/45?tool=ast>(Baz)</a>.