### PR TITLE
chore: don't update dependencies via uv sync in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           enable-cache: true
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --frozen
       - uses: actions/cache@v4
         with:
           path: ${{ env.MYPY_CACHE_DIR }}
@@ -56,6 +56,6 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --frozen
       - name: Run pytest
         run: uv run --frozen python -m pytest tests/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           enable-cache: false
       - name: Install dependencies
-        run: uv sync --locked --no-dev
+        run: uv sync --frozen --no-dev
       - name: Build Python package
         run: uv build
       - name: Publish Release to PyPI


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Modify GitHub Actions workflows to prevent automatic dependency updates during CI runs by adding the <code>--frozen</code> flag to <code>uv sync</code> commands in both PR and release workflows. Enhance build stability by ensuring exact dependency versions are used during CI/CD processes.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gruebel</td><td>chore-migrate-to-uv-52</td><td>June 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @gruebel and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/falken-trace-py/56?tool=ast>(Baz)</a>.